### PR TITLE
settling tank

### DIFF
--- a/config/ars_nouveau/glyph_grow.toml
+++ b/config/ars_nouveau/glyph_grow.toml
@@ -5,7 +5,7 @@
 	#Cost
 	# Default: 70
 	# Range: > -2147483648
-	cost = 70
+	cost = 30
 	#Is Starter Glyph?
 	starter = false
 	#The maximum number of times this glyph may appear in a single spell

--- a/kubejs/assets/mi_tweaks/blockstates/settling_tank.json
+++ b/kubejs/assets/mi_tweaks/blockstates/settling_tank.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "mi_tweaks:block/settling_tank"
+        }
+    }
+}

--- a/kubejs/assets/mi_tweaks/lang/en_us.json
+++ b/kubejs/assets/mi_tweaks/lang/en_us.json
@@ -1,4 +1,7 @@
 {
     "block.mi_tweaks.dilapidated_boiler": "Dilapidated Boiler",
-    "rei_categories.mi_tweaks.dilapidated_boiler": "Dilapidated Boiler"
+    "rei_categories.mi_tweaks.dilapidated_boiler": "Dilapidated Boiler",
+
+    "block.mi_tweaks.settling_tank": "Settling Tank",
+    "rei_categories.mi_tweaks.settling_tank": "Settling Tank"
 }

--- a/kubejs/assets/mi_tweaks/models/block/settling_tank.json
+++ b/kubejs/assets/mi_tweaks/models/block/settling_tank.json
@@ -1,0 +1,13 @@
+{
+    "casing": "bricks",
+    "default_overlays": {
+        "fluid_auto": "modern_industrialization:block/overlays/fluid_auto",
+        "front": "modern_industrialization:block/machines/distillery/overlay_front",
+        "front_active": "modern_industrialization:block/machines/distillery/overlay_front_active",
+        "side": "modern_industrialization:block/machines/distillery/overlay_side",
+        "side_active": "modern_industrialization:block/machines/distillery/overlay_side_active",
+        "item_auto": "modern_industrialization:block/overlays/item_auto",
+        "output": "modern_industrialization:block/overlays/output"
+    },
+    "loader": "modern_industrialization:machine"
+}

--- a/kubejs/assets/mi_tweaks/models/item/settling_tank.json
+++ b/kubejs/assets/mi_tweaks/models/item/settling_tank.json
@@ -1,0 +1,3 @@
+{
+    "parent": "mi_tweaks:block/settling_tank"
+}

--- a/kubejs/data/mi_tweaks/loot_table/blocks/settling_tank.json
+++ b/kubejs/data/mi_tweaks/loot_table/blocks/settling_tank.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "bonus_rolls": 0.0,
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ],
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "mi_tweaks:settling_tank"
+                }
+            ],
+            "rolls": 1.0
+        }
+    ],
+    "random_sequence": "mi_tweaks:blocks/settling_tank"
+}

--- a/kubejs/server_scripts/recipes/aether/shaped.js
+++ b/kubejs/server_scripts/recipes/aether/shaped.js
@@ -39,6 +39,14 @@ ServerEvents.recipes((event) => {
                 C: '#aether:planks_crafting'
             },
             id: `${id_prefix}freezer`
+        },
+        {
+            output: '16x aether:skyroot_stick',
+            pattern: ['A', 'A'],
+            key: {
+                A: '#aether:skyroot_logs'
+            },
+            id: `${id_prefix}skyroot_stick`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/recipes/enigmatica/remove.js
@@ -701,6 +701,7 @@ ServerEvents.recipes((event) => {
         { id: 'utilitarian:utility/paper' },
         { id: 'utilitarian:utility/ice' },
         { id: 'utilitarian:utility/packed_ice' },
+        { id: 'utilitarian:utility/logs_to_sticks' },
         { output: 'utilitarian:angel_block' },
 
         // Ore Processing Removals

--- a/kubejs/server_scripts/recipes/extended_industrialization/composter.js
+++ b/kubejs/server_scripts/recipes/extended_industrialization/composter.js
@@ -27,6 +27,105 @@ ServerEvents.recipes((event) => {
             duration: 5,
             eu: 2,
             id: `${id_prefix}refined_canola_oil`
+        },
+        {
+            item_outputs: [{ item: 'minecraft:redstone', amount: 4 }],
+            item_inputs: [
+                { tag: 'c:clay', amount: 4 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}redstone`
+        },
+        {
+            item_outputs: [{ item: 'ars_nouveau:source_gem', amount: 4 }],
+            item_inputs: [
+                { item: 'aether:ambrosium_shard', amount: 4 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'sauce:source_fluid', amount: 1000 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}source_gem_from_ambrosium_shard`
+        },
+        {
+            item_outputs: [{ item: 'createsifter:raw_gold_piece', amount: 2 }],
+            item_inputs: [
+                { item: 'aquaculture:goldfish', amount: 4 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}raw_gold_piece_from_goldfish`
+        },
+        {
+            item_outputs: [{ item: 'createsifter:raw_iron_piece', amount: 2 }],
+            item_inputs: [
+                { tag: 'c:foods/raw_meats', amount: 4 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}raw_iron_piece_from_raw_meats`
+        },
+        {
+            item_outputs: [{ item: 'minecraft:gunpowder', amount: 3 }],
+            item_inputs: [
+                { item: 'ars_nouveau:bombegranate_pod', amount: 1 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}gunpowder_from_bombegranate_pod`
+        },
+        {
+            item_outputs: [{ item: 'modern_industrialization:ruby_dust', amount: 3 }],
+            item_inputs: [
+                { item: 'ars_nouveau:mendosteen_pod', amount: 1 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}ruby_dust_from_mendosteen_pod`
+        },
+        {
+            item_outputs: [{ item: 'minecraft:glowstone_dust', amount: 3 }],
+            item_inputs: [
+                { item: 'minecraft:glow_berries', amount: 1 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}glowstone_dust_from_glow_berries`
+        },
+        {
+            item_outputs: [{ item: 'enderio:grains_of_infinity', amount: 3 }],
+            item_inputs: [
+                { item: 'ars_nouveau:bastion_pod', amount: 1 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}grains_of_infinity_from_bastion_pod`
+        },
+        {
+            item_outputs: [{ item: 'enderio:ender_crystal_powder', amount: 3 }],
+            item_inputs: [
+                { item: 'ars_elemental:flashpine_pod', amount: 1 },
+                { item: 'theurgy:alchemical_salt_mineral', amount: 1 }
+            ],
+            fluid_inputs: [{ fluid: 'theurgy:sal_ammoniac', amount: 15 }],
+            duration: 5,
+            eu: 2,
+            id: `${id_prefix}ender_crystal_powder_from_flashpine_pod`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/extended_industrialization/shaped.js
+++ b/kubejs/server_scripts/recipes/extended_industrialization/shaped.js
@@ -7,7 +7,7 @@ ServerEvents.recipes((event) => {
             pattern: ['ABA', 'CDC', 'EEE'],
             key: {
                 A: `#c:gears/copper`,
-                B: `minecraft:composter`,
+                B: 'theurgy:digestion_vat',
                 C: `create:propeller`,
                 D: 'modern_industrialization:bronze_machine_casing',
                 E: `ppfluids:fluid_pipe`

--- a/kubejs/server_scripts/recipes/mi_tweaks/settling_tank.js
+++ b/kubejs/server_scripts/recipes/mi_tweaks/settling_tank.js
@@ -1,0 +1,30 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:modern_industrialization/settling_tank/';
+
+    const recipes = [
+        ,
+        {
+            fluid_outputs: [
+                { fluid: 'minecraft:water', amount: 1000 },
+                { fluid: 'industrialforegoing:sludge', amount: 250 }
+            ],
+            item_inputs: [
+                { item: 'minecraft:sand', amount: 1, probability: 0.25 },
+                { item: 'minecraft:gravel', amount: 1, probability: 0.1 }
+            ],
+            fluid_inputs: [{ fluid: 'enigmatica:wastewater', amount: 1000 }],
+            duration: 1,
+            id: `${id_prefix}water_filtering`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'modern_industrialization:settling_tank';
+        recipe.eu = 1;
+        recipe.duration *= 20;
+
+        event.custom(recipe).id(recipe.id);
+
+        if (debug) console.log(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/mi_tweaks/shaped.js
+++ b/kubejs/server_scripts/recipes/mi_tweaks/shaped.js
@@ -1,0 +1,22 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:mi_tweaks/shaped/';
+
+    const recipes = [
+        {
+            output: 'mi_tweaks:settling_tank',
+            pattern: ['ABA', 'ACA', 'ABA'],
+            key: {
+                A: 'minecraft:bricks',
+                B: 'modern_industrialization:steel_tank',
+                C: 'minecraft:iron_trapdoor'
+            },
+            id: `${id_prefix}settling_tank`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+
+        if (debug) console.log(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/minecraft/shaped.js
+++ b/kubejs/server_scripts/recipes/minecraft/shaped.js
@@ -74,6 +74,14 @@ ServerEvents.recipes((event) => {
                 D: 'minecraft:sweet_berries'
             },
             id: `${id_prefix}cake`
+        },
+        {
+            output: '16x minecraft:stick',
+            pattern: ['A', 'A'],
+            key: {
+                A: '#enigmatica:crafts_sticks'
+            },
+            id: `${id_prefix}stick`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/modern_industrialization/centrifuge.js
+++ b/kubejs/server_scripts/recipes/modern_industrialization/centrifuge.js
@@ -24,10 +24,14 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}water`
         },
         {
-            fluid_outputs: [{ fluid: 'extended_industrialization:manure', amount: 100 }],
-            fluid_inputs: { fluid: 'industrialforegoing:sewage', amount: 1000 },
-            eu: 2,
-            duration: 10,
+            item_outputs: [{ item: 'industrialforegoing:fertilizer', amount: 4 }],
+            fluid_outputs: [
+                { fluid: 'extended_industrialization:manure', amount: 1000 },
+                { fluid: 'enigmatica:wastewater', amount: 1000 }
+            ],
+            fluid_inputs: { fluid: 'industrialforegoing:sewage', amount: 8000 },
+            eu: 4,
+            duration: 5,
             id: `${id_prefix}manure`
         },
         {

--- a/kubejs/server_scripts/recipes/oritech/centrifuge_fluid.js
+++ b/kubejs/server_scripts/recipes/oritech/centrifuge_fluid.js
@@ -60,13 +60,14 @@ ServerEvents.recipes((event) => {
             time: 1,
             id: `${id_prefix}water`
         },
-        {
-            results: [],
-            fluidOutputs: [{ fluid: 'extended_industrialization:manure', amount: 100 }],
-            fluidInput: { fluid: 'industrialforegoing:sewage', amount: 1000 },
-            time: 10,
-            id: `${id_prefix}manure`
-        },
+        // {
+        //     results: [],
+        //     fluidOutputs: [{ fluid: 'extended_industrialization:manure', amount: 100 }],
+        //     ingredients: [],
+        //     fluidInput: { fluid: 'industrialforegoing:sewage', amount: 1000 },
+        //     time: 10,
+        //     id: `${id_prefix}manure`
+        // },
         {
             results: [],
             fluidOutputs: [{ fluid: 'industrialforegoing:pink_slime', amount: 100 }],

--- a/kubejs/server_scripts/tags/block/minecraft/mineable.js
+++ b/kubejs/server_scripts/tags/block/minecraft/mineable.js
@@ -4,7 +4,8 @@ ServerEvents.tags('block', (event) => {
             'minecraft:reinforced_deepslate',
             /modern_industrialization:(bronze|steel)_(assembler|centrifuge)/,
             /modern_industrialization:fire_clay_brick_.*_hatch/,
-            'mi_tweaks:dilapidated_boiler'
+            'mi_tweaks:dilapidated_boiler',
+            'mi_tweaks:settling_tank'
         ]
     };
 

--- a/kubejs/server_scripts/tags/block/minecraft/needs_tool.js
+++ b/kubejs/server_scripts/tags/block/minecraft/needs_tool.js
@@ -3,7 +3,8 @@ ServerEvents.tags('block', (event) => {
         stone: [
             /modern_industrialization:(bronze|steel)_(assembler|centrifuge)/,
             /modern_industrialization:fire_clay_brick_.*_hatch/,
-            'mi_tweaks:dilapidated_boiler'
+            'mi_tweaks:dilapidated_boiler',
+            'mi_tweaks:settling_tank'
         ],
         iron: ['minecraft:reinforced_deepslate']
     };

--- a/kubejs/server_scripts/tags/item/enigmatica/crafts_sticks.js
+++ b/kubejs/server_scripts/tags/item/enigmatica/crafts_sticks.js
@@ -1,0 +1,14 @@
+ServerEvents.tags('item', (event) => {
+    let additions = [];
+
+    tree_registry.forEach((tree) => {
+        if (!tree.log.includes('aether:')) {
+            additions.push(tree.log);
+            additions.push(tree.stripped_log);
+            additions.push(tree.wood);
+            additions.push(tree.stripped_wood);
+        }
+    });
+
+    event.get('enigmatica:crafts_sticks').add(additions);
+});

--- a/kubejs/startup_scripts/fluid_registry.js
+++ b/kubejs/startup_scripts/fluid_registry.js
@@ -14,6 +14,11 @@ StartupEvents.registry('fluid', (event) => {
             name: 'Briny Seawater',
             type: 'thin',
             color: 0x75c8ff
+        },
+        {
+            name: 'Wastewater',
+            type: 'thick',
+            color: 0x7d5f33
         }
     ];
 

--- a/kubejs/startup_scripts/machine_registry/settling_tank.js
+++ b/kubejs/startup_scripts/machine_registry/settling_tank.js
@@ -1,0 +1,56 @@
+// https://github.com/AztechMC/Modern-Industrialization/blob/7048dbcb5279d78cf41a49d02bb45ab758e7ce6f/docs/ADDING_MACHINES.md
+
+/*
+    Notes: When adding new machines, allow MI to generate the necessary resources
+    by enabling `datagenOnStartup = true` in `modern_industrialization-startup.toml`.
+    This will generate them in the `modern_industrialization` at the instance root.
+
+    Once generated, the following resources should be copied to `kubejs\assets\modern_industrialization` and `kubejs\data\modern_industrialization`
+    Assets
+    - blockstates
+    - lang (only the specific entries for the new machines)
+    - models
+    Data
+    - loot_table
+
+    Similarly, be sure to update the `minecraft/needs_tool` and `minecraft/mineable` block tags.
+*/
+
+let SETTLING_TANK;
+
+MIMachineEvents.registerRecipeTypes((event) => {
+    SETTLING_TANK = event.register('settling_tank').withItemInputs().withFluidInputs().withFluidOutputs();
+});
+
+MITweaksMachineEvents.registerPowerlessMachines((event) => {
+    event.singleblock(
+        // English name, internal name
+        'Settling Tank',
+        'settling_tank',
+        // Recipe type,
+        SETTLING_TANK,
+        // Background height (or -1 for default value), progress bar
+        190,
+        event.progressBar(83, 53, 'arrow'),
+        // Number of slots: item inputs, item outputs, fluid inputs, fluid outputs
+        2,
+        0,
+        1,
+        2,
+        // Capacity for fluid slots
+        32,
+        // Item slot positions
+        (items) => items.addSlots(42, 47, 1, 2),
+        // Fluid slot positions
+        (fluids) => fluids.addSlots(42, 27, 1, 1).addSlots(129, 47, 1, 2),
+        // Casing of the machine, overlay folder, front overlay?, top overlay?, side overlay?
+        'bricks',
+        'settling_tank',
+        true,
+        false,
+        true,
+        // Base recipe EU, allow redstone control module?
+        1,
+        false
+    );
+});


### PR DESCRIPTION
Grow spell now costs less mana
New machine, the Settling Tank, is used to help recover water from oil processing
Logs > Stick recipe fixed to give aether sticks with aether logs
EI's Composter can now do Theurgy Digestion recipes with a slight output improvement
Iron and Gold are now cheaper to craft