### PR TITLE
Progression continued

### DIFF
--- a/config/ftbquests/quests/chapters/blazing.snbt
+++ b/config/ftbquests/quests/chapters/blazing.snbt
@@ -47,28 +47,6 @@
 			y: -1.5d
 		}
 		{
-			dependencies: ["702AFA5430CF6D73"]
-			id: "4CAD22296114B3AD"
-			tasks: [{
-				id: "613868E595899CED"
-				item: { count: 1, id: "createsifter:crushed_basalt" }
-				type: "item"
-			}]
-			x: 1.0d
-			y: -0.5d
-		}
-		{
-			dependencies: ["0ADEE22CBDE86E54"]
-			id: "1CA3F6B68095E927"
-			tasks: [{
-				id: "4B6822F4E297EC71"
-				item: { count: 1, id: "theurgy:crystallized_lava" }
-				type: "item"
-			}]
-			x: -2.0d
-			y: -0.5d
-		}
-		{
 			dependencies: ["1CF4103BFBCE0E29"]
 			id: "008F3C0FB9F4B451"
 			tasks: [{
@@ -78,28 +56,6 @@
 			}]
 			x: -0.5d
 			y: -3.5d
-		}
-		{
-			dependencies: ["78626EE046E48EF3"]
-			id: "0ADEE22CBDE86E54"
-			tasks: [{
-				id: "03C2D144BC19CB8D"
-				item: { count: 1, id: "aether:golden_aercloud" }
-				type: "item"
-			}]
-			x: -1.5d
-			y: -1.5d
-		}
-		{
-			dependencies: ["0ADEE22CBDE86E54"]
-			id: "09599F64E0788B37"
-			tasks: [{
-				id: "38317B628157BD3F"
-				item: { count: 1, id: "modern_industrialization:sulfur_dust" }
-				type: "item"
-			}]
-			x: -1.0d
-			y: -0.5d
 		}
 		{
 			dependencies: ["78626EE046E48EF3"]
@@ -113,26 +69,6 @@
 			y: -3.0d
 		}
 		{
-			dependencies: ["4CAD22296114B3AD"]
-			id: "4BF9D7B5BB1281B6"
-			tasks: [{
-				id: "5BACB7BA09190E4E"
-				item: { count: 1, id: "malum:blazing_quartz" }
-				type: "item"
-			}]
-			x: 1.0d
-			y: 0.5d
-		}
-		{
-			id: "7CF12A36B30AE7D7"
-			tasks: [{
-				id: "2AD2A5C68D517C53"
-				type: "checkmark"
-			}]
-			x: -3.5d
-			y: 5.5d
-		}
-		{
 			dependencies: ["28E44D5D6A6C1D6E"]
 			id: "41F0CA5ACE335062"
 			tasks: [{
@@ -144,17 +80,14 @@
 			y: 7.0d
 		}
 		{
-			dependencies: [
-				"05F232C12FA99F92"
-				"3C905ECF6E0A543E"
-			]
+			dependencies: ["05F232C12FA99F92"]
 			id: "05B678EEBCC0CDE6"
 			tasks: [{
 				id: "70D805D44A643F1D"
 				item: { count: 1, id: "modern_industrialization:steel_ingot" }
 				type: "item"
 			}]
-			x: 0.0d
+			x: -0.5d
 			y: 2.0d
 		}
 		{
@@ -394,7 +327,10 @@
 			y: 5.5d
 		}
 		{
-			dependencies: ["4DE9FAFF137A075F"]
+			dependencies: [
+				"4DE9FAFF137A075F"
+				"3C905ECF6E0A543E"
+			]
 			icon: {
 				id: "modern_industrialization:electric_kiln"
 			}
@@ -411,22 +347,22 @@
 					type: "item"
 				}
 			]
-			x: -1.5d
-			y: 1.5d
+			x: -0.5d
+			y: 1.0d
 		}
 		{
-			dependencies: ["09599F64E0788B37"]
+			dependencies: ["21EEF7F2B5A695AB"]
 			id: "4DE9FAFF137A075F"
 			tasks: [{
 				id: "46E6D3A918A8044A"
 				item: { count: 1, id: "modern_industrialization:rubber_sheet" }
 				type: "item"
 			}]
-			x: -1.0d
+			x: -1.5d
 			y: 0.5d
 		}
 		{
-			dependencies: ["4BF9D7B5BB1281B6"]
+			dependencies: ["1DB63D0AAD1F0E11"]
 			icon: {
 				id: "justdirethings:coal_t2"
 			}
@@ -444,8 +380,79 @@
 					type: "item"
 				}
 			]
-			x: 1.5d
-			y: 1.5d
+			x: 0.5d
+			y: 0.5d
+		}
+		{
+			dependencies: ["5F9A998072170415"]
+			icon: {
+				id: "enigmatica:volcanic_dorodango"
+			}
+			id: "1DB63D0AAD1F0E11"
+			shape: "diamond"
+			tasks: [
+				{
+					id: "504A332D37BB14BB"
+					item: { count: 1, id: "enigmatica:volcanic_dorodango" }
+					type: "item"
+				}
+				{
+					id: "29778022501F91BD"
+					item: { count: 1, id: "malum:blazing_quartz" }
+					type: "item"
+				}
+				{
+					id: "4B577D9CC7036853"
+					item: { count: 1, id: "modern_industrialization:carbon_dust" }
+					type: "item"
+				}
+				{
+					id: "184D676668A92B2D"
+					item: { count: 1, id: "create:cinder_flour" }
+					type: "item"
+				}
+			]
+			x: 0.0d
+			y: -0.5d
+		}
+		{
+			dependencies: ["78626EE046E48EF3"]
+			id: "5F9A998072170415"
+			shape: "gear"
+			tasks: [{
+				id: "1059B5D1349FE37D"
+				item: { count: 1, id: "ars_nouveau:alakarkinos_charm" }
+				type: "item"
+			}]
+			x: -0.5d
+			y: -1.5d
+		}
+		{
+			dependencies: ["5F9A998072170415"]
+			icon: {
+				id: "enigmatica:sulfurous_dorodango"
+			}
+			id: "21EEF7F2B5A695AB"
+			shape: "diamond"
+			tasks: [
+				{
+					id: "7E9CC56AAD6E6007"
+					item: { count: 1, id: "enigmatica:sulfurous_dorodango" }
+					type: "item"
+				}
+				{
+					id: "21BFC219B266E5AE"
+					item: { count: 1, id: "modern_industrialization:sulfur_dust" }
+					type: "item"
+				}
+				{
+					id: "0FD4A5644A26C2BA"
+					item: { count: 1, id: "theurgy:crystallized_lava" }
+					type: "item"
+				}
+			]
+			x: -1.0d
+			y: -0.5d
 		}
 	]
 }

--- a/config/ftbquests/quests/chapters/cascading.snbt
+++ b/config/ftbquests/quests/chapters/cascading.snbt
@@ -150,6 +150,24 @@
 		{
 			dependencies: ["2BB91161DB6B6AF5"]
 			id: "3CC1C6949E17A1B9"
+			rewards: [
+				{
+					id: "0834F4A8E586677A"
+					item: {
+						count: 1
+						id: "pneumaticcraft:pressure_gauge_module"
+					}
+					type: "item"
+				}
+				{
+					id: "0AB98BDA139B1882"
+					item: {
+						count: 1
+						id: "pneumaticcraft:module_expansion_card"
+					}
+					type: "item"
+				}
+			]
 			tasks: [{
 				id: "4AE35F4C3CBCF69B"
 				item: { count: 1, id: "pneumaticcraft:liquid_compressor" }
@@ -381,7 +399,7 @@
 				type: "item"
 			}]
 			x: 3.5d
-			y: 2.5d
+			y: 3.0d
 		}
 		{
 			dependencies: ["016B7CA4A7FC58A1"]
@@ -495,7 +513,7 @@
 				type: "item"
 			}]
 			x: 3.5d
-			y: 1.5d
+			y: 2.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/chapters/cascading.snbt
+++ b/config/ftbquests/quests/chapters/cascading.snbt
@@ -200,6 +200,9 @@
 		}
 		{
 			dependencies: ["59F0519A7ED69E19"]
+			icon: {
+				id: "pneumaticcraft:refinery"
+			}
 			id: "24095EE1A419152D"
 			tasks: [
 				{

--- a/config/ftbquests/quests/chapters/cascading.snbt
+++ b/config/ftbquests/quests/chapters/cascading.snbt
@@ -49,6 +49,7 @@
 		{
 			dependencies: ["7893072479F01DC2"]
 			id: "6534548E8A6A318C"
+			shape: "gear"
 			tasks: [{
 				id: "421F228364877B59"
 				item: { count: 1, id: "ars_nouveau:alakarkinos_charm" }
@@ -69,26 +70,25 @@
 			y: -2.0d
 		}
 		{
-			dependencies: ["2D190518ABA42A1F"]
-			id: "5A92EF3C51F82669"
-			tasks: [{
-				id: "0EFDC5A1E361B403"
-				item: { count: 1, id: "modern_industrialization:bronze_compressor" }
-				type: "item"
-			}]
-			x: 4.0d
-			y: 1.5d
-		}
-		{
-			dependencies: ["5A92EF3C51F82669"]
+			dependencies: ["3282293AB6B43287"]
+			icon: {
+				id: "pneumaticcraft:ingot_iron_compressed"
+			}
 			id: "2BB91161DB6B6AF5"
-			tasks: [{
-				id: "75D46BE01172D9AB"
-				item: { count: 1, id: "pneumaticcraft:ingot_iron_compressed" }
-				type: "item"
-			}]
-			x: 4.0d
-			y: 2.5d
+			tasks: [
+				{
+					id: "7C1D8FC91C4F26AC"
+					item: { count: 1, id: "modern_industrialization:bronze_compressor" }
+					type: "item"
+				}
+				{
+					id: "070982C11D21C047"
+					item: { count: 1, id: "pneumaticcraft:ingot_iron_compressed" }
+					type: "item"
+				}
+			]
+			x: 3.5d
+			y: 0.5d
 		}
 		{
 			dependencies: ["7893072479F01DC2"]
@@ -109,8 +109,8 @@
 					type: "item"
 				}
 			]
-			x: 2.5d
-			y: -1.5d
+			x: 3.5d
+			y: -3.0d
 		}
 		{
 			dependencies: ["016B7CA4A7FC58A1"]
@@ -155,8 +155,8 @@
 				item: { count: 1, id: "pneumaticcraft:liquid_compressor" }
 				type: "item"
 			}]
-			x: 4.0d
-			y: 3.5d
+			x: 4.5d
+			y: 1.5d
 		}
 		{
 			dependencies: ["2C07E148B9B60809"]
@@ -167,7 +167,7 @@
 				type: "item"
 			}]
 			x: 3.0d
-			y: 5.5d
+			y: 6.0d
 		}
 		{
 			dependencies: ["2C07E148B9B60809"]
@@ -178,13 +178,10 @@
 				type: "item"
 			}]
 			x: 2.0d
-			y: 5.5d
+			y: 6.0d
 		}
 		{
-			dependencies: [
-				"2BB91161DB6B6AF5"
-				"59F0519A7ED69E19"
-			]
+			dependencies: ["59F0519A7ED69E19"]
 			id: "24095EE1A419152D"
 			tasks: [
 				{
@@ -199,7 +196,7 @@
 				}
 			]
 			x: 2.5d
-			y: 3.5d
+			y: 4.0d
 		}
 		{
 			dependencies: ["24095EE1A419152D"]
@@ -210,7 +207,7 @@
 				type: "item"
 			}]
 			x: 2.5d
-			y: 4.5d
+			y: 5.0d
 		}
 		{
 			dependencies: [
@@ -223,7 +220,7 @@
 				item: { count: 1, id: "ae2:fluix_crystal" }
 				type: "item"
 			}]
-			x: 0.0d
+			x: 0.5d
 			y: 0.5d
 		}
 		{
@@ -311,7 +308,7 @@
 					type: "item"
 				}
 			]
-			x: 2.0d
+			x: 1.5d
 			y: 0.5d
 		}
 		{
@@ -339,7 +336,10 @@
 			dependencies: [
 				"4C91792ACCC53A2B"
 				"492FE8CF9B01FCBE"
+				"1476B02AA2977ACB"
+				"6FC31B3806BF222A"
 			]
+			dependency_requirement: "one_completed"
 			icon: {
 				id: "pneumaticcraft:oil_bucket"
 			}
@@ -357,7 +357,7 @@
 					type: "item"
 				}
 			]
-			x: 1.0d
+			x: 2.5d
 			y: 2.5d
 		}
 		{
@@ -368,26 +368,8 @@
 				item: { count: 1, id: "justdirethings:time_crystal" }
 				type: "item"
 			}]
-			x: 0.5d
-			y: 1.5d
-		}
-		{
-			dependencies: ["016B7CA4A7FC58A1"]
-			id: "0DD1FC129B316381"
-			tasks: [
-				{
-					id: "50A98A282C644367"
-					item: { count: 1, id: "create:pulse_repeater" }
-					type: "item"
-				}
-				{
-					id: "6A60507CDB93D49F"
-					item: { count: 1, id: "create:pulse_extender" }
-					type: "item"
-				}
-			]
-			x: -2.5d
-			y: 0.5d
+			x: 2.5d
+			y: 1.0d
 		}
 		{
 			dependencies: ["2BB91161DB6B6AF5"]
@@ -398,8 +380,122 @@
 				item: { count: 1, id: "pneumaticcraft:electrostatic_compressor" }
 				type: "item"
 			}]
-			x: 4.0d
-			y: 4.5d
+			x: 3.5d
+			y: 2.5d
+		}
+		{
+			dependencies: ["016B7CA4A7FC58A1"]
+			icon: {
+				id: "ars_nouveau:potion_diffuser"
+			}
+			id: "46F17885C957FD5C"
+			rewards: [
+				{
+					id: "18702459C0CC8913"
+					item: {
+						components: {
+							"minecraft:potion_contents": {
+								potion: "minecraft:fire_resistance"
+							}
+						}
+						count: 1
+						id: "minecraft:potion"
+					}
+					type: "item"
+				}
+				{
+					id: "20389EFA7D343DE8"
+					item: {
+						components: {
+							"minecraft:potion_contents": {
+								potion: "cold_sweat:ice_resistance"
+							}
+						}
+						count: 1
+						id: "minecraft:potion"
+					}
+					type: "item"
+				}
+			]
+			tasks: [
+				{
+					id: "12A643F7B4597C8C"
+					item: { count: 1, id: "ars_nouveau:potion_diffuser" }
+					type: "item"
+				}
+				{
+					id: "64696B7B29B83C9B"
+					item: { count: 1, id: "ars_nouveau:potion_jar" }
+					type: "item"
+				}
+			]
+			x: -1.5d
+			y: 1.0d
+		}
+		{
+			dependencies: ["7893072479F01DC2"]
+			id: "2722D0A13CF02C73"
+			rewards: [{
+				count: 4
+				id: "4B9B13B526E84B0B"
+				item: {
+					count: 1
+					id: "ars_nouveau:source_gem"
+				}
+				type: "item"
+			}]
+			shape: "diamond"
+			tasks: [{
+				id: "5D77642143DBAAF8"
+				item: { count: 1, id: "starbunclemania:source_condenser" }
+				type: "item"
+			}]
+			x: 2.5d
+			y: -1.5d
+		}
+		{
+			dependencies: [
+				"1476B02AA2977ACB"
+				"6FC31B3806BF222A"
+			]
+			dependency_requirement: "one_completed"
+			icon: {
+				id: "actuallyadditions:lens_of_the_miner"
+			}
+			id: "36A482587B5E89F7"
+			tasks: [
+				{
+					id: "7646560FCF133693"
+					item: { count: 1, id: "actuallyadditions:lens_of_the_miner" }
+					type: "item"
+				}
+				{
+					id: "1E4E5D2B9B36005C"
+					item: { components: { "ftbfiltersystem:filter": "or(item(enigmatica:brilliant_sand)item(enigmatica:brilliant_sculk)item(enigmatica:brilliant_crushed_basalt)item(enigmatica:brilliant_golden_aercloud)item(enigmatica:brilliant_salt)item(enigmatica:brilliant_mud)item(enigmatica:brilliant_cold_aercloud))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+					type: "item"
+				}
+			]
+			x: 4.5d
+			y: 2.5d
+		}
+		{
+			dependencies: ["2BB91161DB6B6AF5"]
+			id: "6FC31B3806BF222A"
+			rewards: [{
+				id: "072E28B488CCFBE3"
+				item: {
+					count: 1
+					id: "pneumaticcraft:heat_sink"
+				}
+				type: "item"
+			}]
+			tasks: [{
+				id: "396F0D469F59671F"
+				item: { count: 1, id: "pneumaticcraft:thermal_compressor" }
+				type: "item"
+			}]
+			x: 3.5d
+			y: 1.5d
 		}
 	]
 }

--- a/config/ftbquests/quests/chapters/flashing.snbt
+++ b/config/ftbquests/quests/chapters/flashing.snbt
@@ -96,6 +96,7 @@
 		{
 			dependencies: ["768869D763EC54EB"]
 			id: "55D51F58CA3130AA"
+			shape: "gear"
 			tasks: [{
 				id: "252408AD422FDB0D"
 				item: { count: 1, id: "ars_nouveau:alakarkinos_charm" }

--- a/config/ftbquests/quests/chapters/flourishing.snbt
+++ b/config/ftbquests/quests/chapters/flourishing.snbt
@@ -425,7 +425,7 @@
 				item: { components: { "ftbfiltersystem:filter": "or(item(actuallyadditions:breaker)item(actuallyadditions:placer)item(actuallyadditions:fluid_collector)item(actuallyadditions:fluid_placer)item(starbunclemania:star_miner)item(starbunclemania:star_build))" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
-			x: 2.5d
+			x: 2.0d
 			y: -3.0d
 		}
 		{
@@ -688,7 +688,7 @@
 				item: { count: 1, id: "ars_nouveau:ritual_harvest" }
 				type: "item"
 			}]
-			x: 2.0d
+			x: 2.5d
 			y: -2.5d
 		}
 		{
@@ -706,9 +706,10 @@
 			tasks: [{
 				id: "5830749F0A254E26"
 				item: { components: { "naturesaura:effect_powder_data": { effect: "naturesaura:animal" } }, count: 1, id: "naturesaura:effect_powder" }
+				match_components: "strict"
 				type: "item"
 			}]
-			x: 2.0d
+			x: 2.5d
 			y: -3.5d
 		}
 		{
@@ -858,6 +859,32 @@
 			}]
 			x: 4.0d
 			y: 5.0d
+		}
+		{
+			dependencies: ["6806970967942788"]
+			id: "0DD1FC129B316381"
+			rewards: [{
+				id: "3274F4AA07A90151"
+				item: {
+					count: 1
+					id: "create:pulse_timer"
+				}
+				type: "item"
+			}]
+			tasks: [
+				{
+					id: "50A98A282C644367"
+					item: { count: 1, id: "create:pulse_repeater" }
+					type: "item"
+				}
+				{
+					id: "6A60507CDB93D49F"
+					item: { count: 1, id: "create:pulse_extender" }
+					type: "item"
+				}
+			]
+			x: 6.5d
+			y: 2.0d
 		}
 	]
 }

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -573,6 +573,11 @@
 		"   nearby mobs on activation."
 	]
 	quest.0DA6F0172E06CCB1.title: "Just Dire Armor"
+	quest.0DD1FC129B316381.quest_desc: [
+		"These Redstone devices can be exceptionally useful for automating some of the processes in this chapter."
+		""
+		"Get creative and have a look around at other devices that might be useful, such as those from the &7Redstone Pen&r mod or even simple vanilla blocks like the &7Observer&r. "
+	]
 	quest.0DE5D9ADB947B171.quest_desc: [
 		"Animate a Wilden Chimera and defeat it to obtain a Wilden Tribute."
 		""
@@ -1147,7 +1152,7 @@
 		""
 		"For example, hold six powders and place them on the ground. All six will be placed as a single entity and their effect will cover a six-block radius. "
 		""
-		"Right-Click the floating powder with your Mystical Magnifier to visualize the area."
+		"Right-Click the floating powder with your &7Mystical Magnifier&r to visualize the area."
 		""
 		"&a🛈 Tip: Powders may be removed  "
 		"&a    by punching them."
@@ -1245,6 +1250,15 @@
 		"But what if you could make your own friends? Cute, lovable, huggable friends that would spark joy just by being around? "
 	]
 	quest.1DA29F3B45DEFB4B.title: "Magical Friends"
+	quest.1DB63D0AAD1F0E11.quest_desc: [
+		"Made from &7Crushed Basalt&r, &7Volcanic Dorodangos&r may be processed down into new materials!"
+		""
+		"  &n&6Materials&r"
+		""
+		"  • &7Blazing Quartz&r"
+		"  • &7Carbon Dust&r"
+		"  • &7Cinder Flour&r"
+	]
 	quest.1E0B03155C2CAEE7.quest_desc: [
 		"Spirit Focusing is an alchemical art whereby a catalyst item, or impetus, is infused with Spirits to generate new materials. "
 		"&n                                                  "
@@ -1404,6 +1418,14 @@
 		"It’s not possible to manually access the Storage Controller, so you’ll likely want to pair this with something else that allows you access the items. An Ad Hoc AE2 network, Pretty Pipes, or an Ars nouveau Storage Lectern are all excellent options."
 	]
 	quest.21C1CAA38D040AC8.title: "Functional Drawers"
+	quest.21EEF7F2B5A695AB.quest_desc: [
+		"Made from &7Golden Aerclouds&r, &7Sulfurous Dorodangos&r may be processed down into new materials!"
+		""
+		"  &n&6Materials&r"
+		""
+		"  • &7Sulfur Dust&r"
+		"  • &7Crystallized Lava&r"
+	]
 	quest.21FA8A625A79BE61.quest_desc: ["Simple fluid pipes for getting fluid from one place to another."]
 	quest.22344008D43D4710.quest_desc: [
 		"Villagers are the soul source of many critical ingredients and their hunger knows no bounds. You’re going to need some help keeping them fed!"
@@ -1604,6 +1626,7 @@
 		"&a    the bottom."
 	]
 	quest.271AC925824B553E.title: "Industrialist"
+	quest.2722D0A13CF02C73.quest_desc: ["A Source Condenser can be a handy way to convert Source into Liquefied Source!"]
 	quest.27B747DE574CF261.quest_desc: [
 		"The next most important resource used by Immersive Engineering is, of course, Steel. IE uses it extensively and it appears in nearly all of it's machines. Given the importance of this material, you'll want to get some cooking sooner rather than later. "
 		"&n                                                  "
@@ -1803,6 +1826,11 @@
 		"While in the Configuration screen, you may add more labels to control the quantity and speed of transfer, as well as set filters."
 		""
 		"The label may be removed by Left-Clicking it with another label or with a Label Accessor."
+	]
+	quest.2BB91161DB6B6AF5.quest_desc: [
+		"What, you thought you’d have to detonate some Iron to make Compressed Iron? "
+		""
+		"Just squish it really hard!"
 	]
 	quest.2BE4C2280C195282.quest_desc: ["Plus Spirit Attuned Gems"]
 	quest.2BE4C2280C195282.title: "Abra's Conjure"
@@ -2156,6 +2184,11 @@
 		""
 		"Experiment with them to see what you like best!"
 	]
+	quest.36A482587B5E89F7.quest_desc: [
+		"Infused with brilliant light, these blocks are favored by Alakarkinos for their beauty. They’ll produce even more Dorodangos from each block! "
+		""
+		"Well worth the extra energy costs, to be sure. "
+	]
 	quest.37C965C1FA40221E.quest_desc: [
 		"&7Spell Turrets&r can be an incredibly powerful automation tool for casting prepared spells. "
 		""
@@ -2375,6 +2408,7 @@
 		"&a    your tools running longer!"
 	]
 	quest.3C50D5FE5FA787A9.quest_desc: ["For when you just need a big fracking gun to tell the monster hordes who’s boss. "]
+	quest.3C905ECF6E0A543E.quest_desc: ["Blaze Ember is critical to improved fuel production as well as to the production of Steel. "]
 	quest.3CA4472228D0F866.quest_desc: [
 		"By adding an ME Controller to a network, we gain access to far more channels; 32 per side, in fact. "
 		""
@@ -3080,6 +3114,11 @@
 		"&6⚠ Note: The structure will accept "
 		"&6    any Steel Block. "
 	]
+	quest.46F17885C957FD5C.quest_desc: [
+		"Potions of &7Fire Resistance&r and &7Ice Resistance&r won’t affect your body temperature, but they will prevent any negative effects associated with being too &9cold&r or &chot&r, making them ideal for prolonged jaunts outside of the area of your Hearth."
+		""
+		"By feeding them into a &7Potion Diffuser&r, you can even share the effects with your friends or other entities in the area."
+	]
 	quest.471571E3E382B404.quest_desc: [
 		"String Curtains are a wonderful way to decorate your home, but they can also be quite functional!"
 		""
@@ -3235,6 +3274,13 @@
 		"With your dark powers combined, you’ll finally be able to craft a Blood Infuser. "
 		""
 		"This’ll make the previous process a little less messy, and considerably cheaper. "
+	]
+	quest.492FE8CF9B01FCBE.quest_desc: [
+		"[ \"Obtaining the materials to create these will require a visit to the \", { \"text\": \"Flashing Island\", \"color\":\"aqua\", \"underlined\": true, \"clickEvent\": { \"action\": \"change_page\", \"value\": \"19F8B29D38CA31B8\" },\"hoverEvent\":{\"action\":\"show_text\",\"value\":[{\"text\":\"Click Here\"}]} }, \". \" ]"
+		""
+		"Once you’ve obtained the requisite &7Flashpine&r, however, the only thing standing in your way is Time itself."
+		""
+		"And Aura. Lots of Aura."
 	]
 	quest.49878D1219A63A4E.quest_desc: [
 		"Just another solar panel. It produces power during daylight hours and works best if paired with an Energy Cube or other power storage device."
@@ -3412,7 +3458,6 @@
 	]
 	quest.4C7D7FC6EEB07515.title: "Barrels"
 	quest.4C8FBFE52DD15C71.title: "Shepherd"
-	quest.4CAD22296114B3AD.quest_desc: [""]
 	quest.4CB21D6351486281.quest_desc: [
 		"Catalysts may be installed on a Natural Altar to modify the recipes it can process."
 		""
@@ -3875,7 +3920,7 @@
 	quest.57DA648FF73A769A.quest_desc: [
 		"The Thermal Compressor uses heat differentials to produce compressed air up to &710 bar&r. "
 		""
-		"Blocks such as &7Lava&r or &7Magma&r may be used to heat one side while a Heat Sink placed opposite will be enough to produce the required differential. "
+		"Blocks such as &7Lava&r or &7Magma&r may be used to heat one side while a &7Heat Sink&r placed opposite will be enough to produce the required differential. "
 		""
 		"Heat sources will degrade over time and will need to be replaced."
 		""
@@ -3935,9 +3980,9 @@
 	quest.59F0519A7ED69E19.quest_desc: [
 		"Oil is normally formed under intense pressure over millions of years."
 		""
-		"We don't have time for that, so let's speed things along a little with the magic of &7Time Fluid&r."
+		"Ain't nobody got time for that."
 		""
-		"Reaching the necessary pressure here may prove difficult. You'll need to use a &7Thermal Compressor&r for these pressures."
+		"Let's speed things along a little with the magic of &7Time Fluid&r."
 	]
 	quest.59F0519A7ED69E19.title: "Crude Oil"
 	quest.5A74D7EFD6AD1EAC.quest_desc: [
@@ -5063,6 +5108,16 @@
 		"&a    placed on Dense Cables."
 	]
 	quest.6FA4894900E53B31.quest_desc: ["In need of some saplings? Maybe you’d like to get some bees producing honey? Summon forth the Queen Bee in her throne and see what trades she has to offer!"]
+	quest.6FC31B3806BF222A.quest_desc: [
+		"The Thermal Compressor uses heat differentials to produce compressed air up to &710 bar&r. "
+		""
+		"Blocks such as &7Lava&r or &7Magma&r may be used to heat one side while a &7Heat Sink&r placed opposite will be enough to produce the required differential. "
+		""
+		"Heat sources will degrade over time and will need to be replaced."
+		""
+		"&a🛈 Tip: Look at Uses for Heat Pipes in"
+		"&a    EMI for a list of heat sources."
+	]
 	quest.70122FCB0A26D96B.quest_desc: [
 		"You may have seen some suspicious looking Deepslate boulders lying around in certain biomes. While they might just seem like an easy way to get some early resources, they hide a treasure trove beneath them."
 		""
@@ -5430,7 +5485,7 @@
 		"  • &7C. Deepslate&r           &2⟶&r           &7Basalt&r"
 		"  • &7Deepslate&r              &2⟶&r           &7Smooth Basalt&r"
 		""
-		"                      &c⚠ Warning: Contents HOT!"
+		"                    &c⚠ Warning: Contents HOT!"
 		"{@pagebreak}"
 		"&6&nExample Spells&r"
 		""
@@ -5753,6 +5808,7 @@
 	task.1D1C35B0CD86F6CC.title: "Any Fluid Drawer"
 	task.1D4765846A798B24.title: "Any Modern Industrialization Barrel"
 	task.1E437E1BEE76E5FF.title: "Terminals"
+	task.1E4E5D2B9B36005C.title: "Brilliant Blocks"
 	task.210DF794EE1D714A.title: "Observation: &2Wixie's Stonecutter&r"
 	task.213012F4279A21AF.title: "Chemical Tanks"
 	task.23F893300571CCAF.title: "Summon: Djinni Crusher"

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -3412,6 +3412,7 @@
 	]
 	quest.4C7D7FC6EEB07515.title: "Barrels"
 	quest.4C8FBFE52DD15C71.title: "Shepherd"
+	quest.4CAD22296114B3AD.quest_desc: [""]
 	quest.4CB21D6351486281.quest_desc: [
 		"Catalysts may be installed on a Natural Altar to modify the recipes it can process."
 		""
@@ -5073,14 +5074,7 @@
 		""
 		"Items may only be accessed by pipe or other logistics. There’s a round slot on the front for this purpose. "
 	]
-	quest.702AFA5430CF6D73.quest_desc: [
-		"cobblestone conversion in hot biome?"
-		""
-		""
-		"Crush to dust, get lava crystal from that. "
-		""
-		"Extract remaining minerals from lava?"
-	]
+	quest.702AFA5430CF6D73.quest_desc: [""]
 	quest.702F469E14D94B63.title: "Uphyxes Inverted Tower"
 	quest.70C8E621A4B76BD6.quest_desc: [
 		"With EV Energy Hatches, your Large Steam Turbines can be upgraded quite simply by swapping out the hatch. This will allow them to reach their full potential, and immediately double their output, assuming they have enough Steam."

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -2444,7 +2444,7 @@
 	]
 	quest.3CBA1384BD3D28ED.title: "Wixie Smelting"
 	quest.3CC1C6949E17A1B9.quest_desc: [
-		"Simple and reliable, the Liquid Compressor is suitable for running basic PneumaticCraft machines. "
+		"Simple and reliable, the &7Liquid Compressor&r is suitable for running basic PneumaticCraft machines up to &75 bar&r. "
 		"&n                                                  &r"
 		""
 		"Machines and Tubes will burst if over pressurized! Avoid this by disabling the Compressor when it’s nearly full. "

--- a/config/naturesaura-common.toml
+++ b/config/naturesaura-common.toml
@@ -8,7 +8,21 @@
 	#Blocks that are exempt from being recognized as generatable ores for the passive ore generation effect. Each entry needs to be formatted as modid:block[prop1=value1,...] where block state properties are optional, and entries follow standard TOML array formatting (https://toml.io/en/v1.0.0#array).
 	oreExceptions = []
 	#Blocks that are exept from being fertilized by the plant boost effect. Each entry needs to be formatted as modid:block, and entries follow standard TOML array formatting (https://toml.io/en/v1.0.0#array).
-	plantBoostExceptions = []
+	plantBoostExceptions = [
+		"aether:aether_grass_block", 
+		"aether:enchanted_aether_grass_block", 
+		"minecraft:grass_block", 
+		"minecraft:moss_block", 
+		"naturesaura:nether_grass",
+		"malum:blighted_growth",
+		"malum:blightroot",
+		"malum:blighted_earth",
+		"malum:blight",
+		"malum:scarstone",
+		"malum:strangeroot",
+		"malum:strange_crystal",
+		"malum:large_strange_crystal"
+		]
 	#Additional projectile types that are allowed to be consumed by the projectile generator. Each entry needs to be formatted as entity_registry_name->aura_amount, and entries follow standard TOML array formatting (https://toml.io/en/v1.0.0#array).
 	additionalProjectiles = [
 		"minecraft:llama_spit->0",

--- a/kubejs/server_scripts/recipes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/recipes/ars_nouveau/enchanting_apparatus.js
@@ -537,6 +537,21 @@ ServerEvents.recipes((event) => {
             keepNbtOfReagent: false,
             sourceCost: 10000,
             id: `${id_prefix}clock_hand`
+        },
+        {
+            result: { id: 'ars_nouveau:potion_diffuser', count: 1 },
+            reagent: { item: 'supplementaries:bellows' },
+            pedestalItems: [
+                { tag: 'c:ingots/hallowed_gold' },
+                { tag: 'c:ingots/hallowed_gold' },
+                { tag: 'c:ingots/hallowed_gold' },
+                { item: 'naturesaura:infused_stone' },
+                { item: 'naturesaura:infused_stone' },
+                { item: 'naturesaura:infused_stone' }
+            ],
+            keepNbtOfReagent: false,
+            sourceCost: 0,
+            id: `${id_prefix}potion_diffuser`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/ars_nouveau/imbuement.js
+++ b/kubejs/server_scripts/recipes/ars_nouveau/imbuement.js
@@ -114,13 +114,6 @@ ServerEvents.recipes((event) => {
             source: 6000,
             id: `${id_prefix}anima_essence_from_block`
         },
-        {
-            output: { id: 'ars_nouveau:source_gem_block', count: 1 },
-            input: { tag: 'c:storage_blocks/amethyst' },
-            pedestalItems: [],
-            source: 500 * 3,
-            id: `ars_nouveau:amethyst_block`
-        },
 
         {
             output: Item.of(

--- a/kubejs/server_scripts/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/recipes/enigmatica/remove.js
@@ -119,6 +119,7 @@ ServerEvents.recipes((event) => {
         { id: 'ars_nouveau:first_armor_upgrade' },
         { id: 'ars_nouveau:second_armor_upgrade' },
         { id: 'ars_nouveau:splash_flask_cannon' },
+        { id: 'ars_nouveau:potion_diffuser' },
         { id: /ars_nouveau:manipulation_essence_to_.*_sapling/ },
         { id: /ars_elemental:(piercing|homing|arc|deceleration|acceleration)_prism_lens/ },
         { id: /ars_nouveau:(cobblestone|stone|sand|gravel)/ },

--- a/kubejs/server_scripts/recipes/enigmatica/simple_crushing.js
+++ b/kubejs/server_scripts/recipes/enigmatica/simple_crushing.js
@@ -380,7 +380,7 @@ ServerEvents.recipes((event) => {
             id_suffix: 'crushed_end_stone'
         },
         {
-            input: { item: 'minecraft:basalt' },
+            input: { item: 'minecraft:smooth_basalt' },
             outputs: [{ id: 'createsifter:crushed_basalt', count: 1 }],
             multiply: 'none',
             exclusions: ['create:milling'],

--- a/kubejs/server_scripts/recipes/minecraft/potion_brewing.js
+++ b/kubejs/server_scripts/recipes/minecraft/potion_brewing.js
@@ -3,9 +3,14 @@ MoreJS.registerPotionBrewing((event) => {
 
     const recipes = [
         {
-            reagent: 'ars_nouveau:fire_essence',
+            reagent: 'ars_nouveau:bombegranate_pod',
             input: 'minecraft:awkward',
             output: 'minecraft:fire_resistance'
+        },
+        {
+            reagent: 'ars_nouveau:frostaya_pod',
+            input: 'minecraft:awkward',
+            output: 'cold_sweat:ice_resistance'
         },
         {
             reagent: 'minecraft:honeycomb',

--- a/kubejs/server_scripts/recipes/naturesaura/offering.js
+++ b/kubejs/server_scripts/recipes/naturesaura/offering.js
@@ -9,6 +9,12 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}stainless_steel_ingot`
         },
         {
+            output: { id: 'modern_industrialization:stainless_steel_block', count: 1 },
+            input: { tag: 'c:storage_blocks/soul_stained_steel' },
+            start_item: { item: 'malum:iridescent_ether' },
+            id: `${id_prefix}stainless_steel_block`
+        },
+        {
             output: { id: 'actuallyadditions:coffee_cup', count: 1 },
             input: { item: 'actuallyadditions:empty_cup' },
             start_item: { item: 'aether:life_shard' },

--- a/kubejs/server_scripts/recipes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/recipes/pneumaticcraft/thermo_plant.js
@@ -134,6 +134,7 @@ ServerEvents.recipes((event) => {
             inputs: { item: { item: 'minecraft:dandelion' } },
             pressure: 4.0,
             temperature: { min: CtoK(100) },
+            speed: 4.0,
             id: `${id_prefix}latex_from_dandelion`
         },
         {
@@ -141,6 +142,7 @@ ServerEvents.recipes((event) => {
             inputs: { item: { item: 'minecraft:vine' } },
             pressure: 4.0,
             temperature: { min: CtoK(100) },
+            speed: 2.0,
             id: `${id_prefix}latex_from_vine`
         },
         {


### PR DESCRIPTION
- Crushed Basalt now comes from Smooth Basalt. This means current spell turrets will need to be reprogrammed. It's done to make for a smoother experience when producing Crushed Basalt from a single spell, as it no longer needs a delay. 
`Touch > Conjure Terrain > Amp X2 > Smelt > Crush`
- Latex now crafts faster in TPP. Flowers get a 2x modifier on speed since they produce less than Vines, making the two crafts roughly equivalent. 
- Fire and Ice Resistance potions have new recipes, being crafted from Bombegranate and Frostaya pods, respectively. 
- Nature's Aura no longer grows grass on grass
- Quest updates, including callouts for the Potion Diffuser