### PR TITLE
feat(i18n): Add the missing translation keys

### DIFF
--- a/config/ftbquests/quests/chapters/acclimation.snbt
+++ b/config/ftbquests/quests/chapters/acclimation.snbt
@@ -41,7 +41,7 @@
 					id: "6CA06EEB4813A544"
 					item: {
 						components: {
-							"minecraft:custom_name": "{\"color\":\"dark_purple\",\"italic\":true,\"text\":\"Cloud Burst\"}"
+							"minecraft:custom_name": "{\"color\":\"dark_purple\",\"italic\":true,\"translate\":\"item.enigmatica.caster_tome.cloud_burst\"}"
 							"sauce:school_tome_caster": {
 								flavor_text: "Conjures a single fluffy cloud provided it's cold enough."
 								hidden_text: "the demon free galvanize "
@@ -283,7 +283,7 @@
 					id: "37389C4060D19A21"
 					item: {
 						components: {
-							"minecraft:custom_name": "{\"color\":\"dark_purple\",\"italic\":true,\"text\":\"Brawndo\"}"
+							"minecraft:custom_name": "{\"color\":\"dark_purple\",\"italic\":true,\"translate\":\"item.enigmatica.caster_tome.brawndo\"}"
 							"sauce:school_tome_caster": {
 								flavor_text: "It's got what plants crave!"
 								hidden_text: "eldritch demon gargleblaster"
@@ -461,7 +461,7 @@
 									}
 								}
 							}
-							"minecraft:custom_name": "{\"color\":\"dark_purple\",\"italic\":true,\"text\":\"Holdfast\"}"
+							"minecraft:custom_name": "{\"color\":\"dark_purple\",\"italic\":true,\"translate\":\"item.enigmatica.caster_tome.holdfast\"}"
 						}
 						count: 1
 						id: "ars_nouveau:caster_tome"

--- a/kubejs/assets/enigmatica/lang/en_us.json
+++ b/kubejs/assets/enigmatica/lang/en_us.json
@@ -101,6 +101,10 @@
     "item.enigmatica.caster_tome.smokenado": "Smokenado",
     "item.enigmatica.caster_tome.firenado": "Firenado",
     "item.enigmatica.caster_tome.ghostnado": "Ghostnado",
+    
+    "item.enigmatica.caster_tome.cloud_burst": "Cloud Burst",
+    "item.enigmatica.caster_tome.brawndo": "Brawndo",
+    "item.enigmatica.caster_tome.holdfast": "Holdfast",
 
     "item.enigmatica.dumpling_drop": "§6CloudDash: §dDumpling Drop",
     "item.enigmatica.great_eggspectations": "§6CloudDash: §rGreat Eggspectations",

--- a/kubejs/assets/enigmatica/lang/en_us.json
+++ b/kubejs/assets/enigmatica/lang/en_us.json
@@ -125,6 +125,7 @@
     "item.enigmatica.pork_pieces": "§aMeatFresh: §7Pork Pieces",
     "item.enigmatica.mutton_morsels": "§aMeatFresh: §7Mutton Morsels",
 
+    "item.enigmatica.flying_cow_iou": "§6IOU:§r 1x Flying Cow",
     "item.enigmatica.phyg_iou": "§6IOU:§r 1x Phyg",
     "item.enigmatica.sheepuff_iou": "§6IOU:§r 1x Sheepuff",
     "item.enigmatica.aerbunny_iou": "§6IOU:§r 1x Aerbunny",


### PR DESCRIPTION
Haha, sorry for posting two PRs in such quick succession, but I just discovered a new issue. It’s not something I can easily fix on my own, so I need to discuss it with you. [Here](https://github.com/EnigmaticaModpacks/EnigmaticSkies/blob/52cff18b9db6ae14decfe237de9167b2edefcd40/kubejs/server_scripts/constants/spell_tomes.js#L5-L6), as well as [elsewhere](https://github.com/EnigmaticaModpacks/EnigmaticSkies/blob/52cff18b9db6ae14decfe237de9167b2edefcd40/config/ftbquests/quests/chapters/it_takes_a_village.snbt#L1132-L1133), we’ve found texts—but unlike ordinary lore or tooltips registered in other ways, this is `flavor_text` or `hidden_text`.

After looking into it, I discovered that this item component is registered by the `Ars Nouveau` mod. To make matters worse, this item component does not support translation keys, which means it’s difficult for us to localize it. Here is the mod’s source code I referenced: https://github.com/baileyholl/Ars-Nouveau/blob/48674342c0bd4999c7b99ebbd5922bdebf67d91b/src/main/java/com/hollingsworth/arsnouveau/api/spell/AbstractCaster.java#L388

What I’d like to discuss with you is how best to handle these texts. I think they should be translated, so we may need to register this tooltip using a different method, or find another solution. It’s up to you, so we need to talk it over.