### PR TITLE
Karkis no longer sit in seats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NeoForge-1.21.1-21.1.230 |
 
 #### 🦟 Bugs Fixed
 
+- Karkis are no longer allowed in Create seats since it breaks them [(\#208)](https://github.com/EnigmaticaModpacks/EnigmaticSkies/issues/208)
+
 #### ✔️ Added Mods
 
 #### ❌ Removed Mods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NeoForge-1.21.1-21.1.230 |
 
 #### 🦟 Bugs Fixed
 
-- Karkis are no longer allowed in Create seats since it breaks them [(\#208)](https://github.com/EnigmaticaModpacks/EnigmaticSkies/issues/208)
+- Karkis are no longer allowed in Create seats since it breaks them [(\#209)](https://github.com/EnigmaticaModpacks/EnigmaticSkies/issues/209)
 
 #### ✔️ Added Mods
 

--- a/kubejs/server_scripts/tags/entity_type/neoforge/capturing_not_supported.js
+++ b/kubejs/server_scripts/tags/entity_type/neoforge/capturing_not_supported.js
@@ -1,0 +1,4 @@
+ServerEvents.tags('entity_type', (event) => {
+    let additions = ['ars_nouveau:alakarkinos'];
+    event.get('c:capturing_not_supported').add(additions);
+});


### PR DESCRIPTION
- Karkis are no longer allowed in Create seats since it breaks them